### PR TITLE
HotFix the installation instructions. 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -9,7 +9,7 @@ Currently, this module only supports the ES2017 (ES8) specification.
 ## Installation Using [npm](https://docs.npmjs.com/getting-started/installing-npm-packages-locally)
 
 ```
-npm install es-abstract-to-integer
+npm install es-abstract-to-length
 ```
 
 ## Example Usage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-abstract-to-length",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A method to convert an argument to an integer suitable for use as the length of an array-like object. This method follows ECMAScript's specification for the 'ToLength' abstract operation.",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
It should reference `es-abstract-to-length` not `es-abstract-to-integer`